### PR TITLE
chore: update postgres aurora version

### DIFF
--- a/terraform/modules/gost_postgres/main.tf
+++ b/terraform/modules/gost_postgres/main.tf
@@ -2,9 +2,9 @@ data "aws_region" "current" {}
 data "aws_partition" "current" {}
 data "aws_caller_identity" "current" {}
 
-data "aws_rds_engine_version" "postgres13_13" {
+data "aws_rds_engine_version" "postgres13_18" {
   engine  = "aurora-postgresql"
-  version = "13.13"
+  version = "13.18"
 }
 
 terraform {
@@ -56,8 +56,8 @@ module "db" {
 
   name                       = "${var.namespace}-postgres"
   cluster_use_name_prefix    = true
-  engine                     = data.aws_rds_engine_version.postgres13_13.engine
-  engine_version             = data.aws_rds_engine_version.postgres13_13.version
+  engine                     = data.aws_rds_engine_version.postgres13_18.engine
+  engine_version             = data.aws_rds_engine_version.postgres13_18.version
   auto_minor_version_upgrade = true
   engine_mode                = "provisioned"
   storage_encrypted          = true


### PR DESCRIPTION
### Ticket #<Enter Number Here To Auto-Link>
## Description
This PR updates the version of Postgres our Aurora clusters are. When trying to do a separate deployment, I ran in to a terraform error:
```
Error: updating RDS Cluster (nava-gost-stag-postgres-20250206165349254100000001): InvalidParameterCombination: Cannot upgrade aurora-postgresql from 13.18 to 13.13
	status code: 400, request id: 20c32fa4-79f1-48af-a051-827de25ad68b

  with module.postgres.module.db.aws_rds_cluster.this[0],
  on .terraform/modules/postgres.db/main.tf line [39](https://github.com/navapbc/arpa-reporter/actions/runs/15351952162/job/43202496226#step:14:40), in resource "aws_rds_cluster" "this":
  39: resource "aws_rds_cluster" "this" {
```

which indicates that the cluster _is currently 13.18_, but our terraform was trying to put it at 13.13. While the indicated line doesn't seem to directly reference this, I think the bit I've changed does.

## Screenshots / Demo Video

## Testing

### Automated and Unit Tests
- [ ] Added Unit tests

### Manual tests for Reviewer
- [ ] Added steps to test feature/functionality manually

## Checklist
- [ ] Provided ticket and description
- [ ] Provided screenshots/demo
- [ ] Provided testing information
- [ ] Provided adequate test coverage for all new code
- [ ] Added PR reviewers