### PR TITLE
Scale the DB based on Audit Reports failing

### DIFF
--- a/terraform/modules/gost_postgres/main.tf
+++ b/terraform/modules/gost_postgres/main.tf
@@ -95,8 +95,8 @@ module "db" {
   copy_tags_to_snapshot = true
 
   serverlessv2_scaling_configuration = {
-    min_capacity = 0.5
-    max_capacity = 1.5
+    min_capacity = 2
+    max_capacity = 4
   }
 
   instance_class = "db.serverless"


### PR DESCRIPTION
### Ticket #396 
## Description

Looks like the Audit report failing happens at a time where the CPU on the DB spikes to 100% and stays there for about 15 minutes. At the end of that time, the Audit Report fails to get a connection to the DB. It looks like the DB Connection Pool on the API containers may have grown to the point where the server is exhausted of connections. This is likely a symptom not the cause, as the locked CPU would mean queries queue up, more connection pool connections are opened to accommodate and then never closed.

Scaling the DB to get two things:
1. More headroom for the process spiking the CPU to run faster and finish (may not be the audit report)
2. Assign enough Aurora Compute Units to get Performance Monitoring enabled and potentially troubleshoot the slow query more easily.


## Screenshots / Demo Video

## Testing
1. Deploy scaling changes to Prod
3. Monitor for CPU usage while running the Audit report

### Automated and Unit Tests
- [x] Added Unit tests - n/a

### Manual tests for Reviewer
- [x] Added steps to test feature/functionality manually

## Checklist
- [x] Provided ticket and description
- [x] Provided screenshots/demo
- [x] Provided testing information
- [x] Provided adequate test coverage for all new code
- [ ] Added PR reviewers