### PR TITLE
Chore [deps:terraform]: update datadog/datadog requirement from ~> 3.…

### DIFF
--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -8,7 +8,7 @@ terraform {
     }
     datadog = {
       source  = "DataDog/datadog"
-      version = "~> 3.63.0"
+      version = "~> 4.15.0"
     }
   }
 


### PR DESCRIPTION
…63.0 to ~> 4.15.0

Updates the requirements on [datadog/datadog](https://github.com/DataDog/terraform-provider-datadog) to permit the latest version.
- [Release notes](https://github.com/DataDog/terraform-provider-datadog/releases)
- [Changelog](https://github.com/DataDog/terraform-provider-datadog/blob/master/CHANGELOG.md)
- [Commits](https://github.com/DataDog/terraform-provider-datadog/compare/v3.63.0...v4.15.0)

---
updated-dependencies:
- dependency-name: datadog/datadog dependency-version: 4.15.0 dependency-type: direct:production ...

### Ticket #<Enter Number Here To Auto-Link>
## Description

## Screenshots / Demo Video

## Testing

### Automated and Unit Tests
- [ ] Added Unit tests

### Manual tests for Reviewer
- [ ] Added steps to test feature/functionality manually

## Checklist
- [ ] Provided ticket and description
- [ ] Provided screenshots/demo
- [ ] Provided testing information
- [ ] Provided adequate test coverage for all new code
- [ ] Added PR reviewers